### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/pyinrail/pyinrail.py
+++ b/pyinrail/pyinrail.py
@@ -7,7 +7,7 @@ import demjson
 import pytesseract
 import pandas as pd
 from PIL import Image
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 from .utils import *
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ demjson==2.2.4
 pytesseract==0.2.0
 pandas==0.21.0
 Pillow==5.0.0
-fuzzywuzzy==0.15.1
+rapidfuzz==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(name='pyinrail',
 	author_email='nikhilksingh97@gmail.com',
 	license='MIT',
 	packages=['pyinrail'],
-	install_requires=['requests',  'demjson', 'pandas', 'Pillow', 'pytesseract', 'fuzzywuzzy'],
+	install_requires=['requests',  'demjson', 'pandas', 'Pillow', 'pytesseract', 'rapidfuzz'],
 	include_package_data=True,
 	zip_safe=False)


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.